### PR TITLE
Backend optimizations

### DIFF
--- a/apps/server/src/auth/auth-google.servive.ts
+++ b/apps/server/src/auth/auth-google.servive.ts
@@ -34,9 +34,7 @@ export class AuthGoogleService {
       idToken: token,
       audience: [process.env.GOOGLE_CLIENT_ID],
     });
-
-    console.log(ticket);
-
+    
     const data = ticket.getPayload();
 
     return {

--- a/apps/server/src/database/db-seeder.ts
+++ b/apps/server/src/database/db-seeder.ts
@@ -9,9 +9,9 @@ import { Repeat, RepeatType } from '../tasks/entities/repeat.entity';
 import { Task } from '../tasks/entities/task.entity';
 import { TasksService } from '../tasks/tasks.service';
 import { User } from '../users/entities/user.entity';
-import { newDate } from '../utils/myDate';
 import { TaskPlanner } from '../workers/taskPlanner';
 import { InitialSeed } from './initial-seed';
+import newDate from '../utils/newDate';
 
 // TODO This needs to be changed to adapt new functionality
 
@@ -127,7 +127,7 @@ export const seedDatabase = async (app: INestApplication) => {
     taskName: 'Sleep',
     category: sleepingCategory,
     // New date in utc
-    start: newDate(new Date(2022, 12, 12, 0)),
+    start: newDate(2022, 12, 12, 0),
     duration: moment.duration(8, 'hours'),
     user: user,
     priority: 'high',
@@ -138,91 +138,91 @@ export const seedDatabase = async (app: INestApplication) => {
   await createConstTask({
     taskName: 'Imperative Programming',
     category: lectures_category,
-    start: newDate(new Date(2022, 12, 12, 11, 15)),
+    start: newDate(2022, 12, 12, 11, 15),
     user,
   });
 
   await createConstTask({
     taskName: 'English Language',
     category: labs_category,
-    start: newDate(new Date(2022, 12, 12, 14)),
+    start: newDate(2022, 12, 12, 14),
     user,
   });
 
   await createConstTask({
     taskName: 'Algorithms and Data Structures',
     category: labs_category,
-    start: newDate(new Date(2022, 12, 13, 9, 35)),
+    start: newDate(2022, 12, 13, 9, 35),
     user,
   });
 
   await createConstTask({
     taskName: 'Mathematic Analysis',
     category: lectures_category,
-    start: newDate(new Date(2022, 12, 13, 11, 15)),
+    start: newDate(2022, 12, 13, 11, 15),
     user,
   });
 
   await createConstTask({
     taskName: 'Mathematical Logic',
     category: labs_category,
-    start: newDate(new Date(2022, 12, 13, 16, 15)),
+    start: newDate(2022, 12, 13, 16, 15),
     user,
   });
 
   await createConstTask({
     taskName: 'Physics',
     category: labs_category,
-    start: newDate(new Date(2022, 12, 14, 8)),
+    start: newDate(2022, 12, 14, 8),
     user,
   });
 
   await createConstTask({
     taskName: 'Mathematical Logic',
     category: lectures_category,
-    start: newDate(new Date(2022, 12, 14, 11, 15)),
+    start: newDate(2022, 12, 14, 11, 15),
     user,
   });
 
   await createConstTask({
     taskName: 'Intellectual Property',
     category: lectures_category,
-    start: newDate(new Date(2022, 12, 14, 12, 50)),
+    start: newDate(2022, 12, 14, 12, 50),
     user,
   });
 
   await createConstTask({
     taskName: 'Algorithms and Data Structures',
     category: lectures_category,
-    start: newDate(new Date(2022, 12, 14, 14, 40)),
+    start: newDate(2022, 12, 14, 14, 40),
     user,
   });
 
   await createConstTask({
     taskName: 'Mathematical Analysis',
     category: labs_category,
-    start: newDate(new Date(2022, 12, 15, 14, 15)),
+    start: newDate(2022, 12, 15, 14, 15),
     user,
   });
 
   await createConstTask({
     taskName: 'Physics',
     category: lectures_category,
-    start: newDate(new Date(2022, 12, 15, 15, 45)),
+    start: newDate(2022, 12, 15, 15, 45),
     user,
   });
 
   await createConstTask({
     taskName: 'Physical Education',
     category: labs_category,
-    start: newDate(new Date(2022, 12, 16, 10, 15)),
+    start: newDate(2022, 12, 16, 10, 15),
     user,
   });
 
   await createConstTask({
     taskName: 'Imperative Programming',
     category: labs_category,
-    start: newDate(new Date(2022, 12, 16, 14, 40)),
+    start: newDate(2022, 12, 16, 14, 40),
     user,
   });
 
@@ -235,10 +235,10 @@ export const seedDatabase = async (app: INestApplication) => {
     isFloat: true,
     user: user,
     chunkInfo: {
-      start: newDate(new Date(2022, 12, 13)),
+      start: newDate(2022, 12, 13),
       minChunkDuration: moment.duration(1, 'hour'),
       maxChunkDuration: moment.duration(3, 'hour'),
-      deadline: newDate(new Date(2022, 12, 25, 0, 0)),
+      deadline: newDate(2022, 12, 25, 0, 0),
       estimation: moment.duration(4, 'hours'),
       chillTime: moment.duration(15, 'minutes'),
     },
@@ -248,13 +248,13 @@ export const seedDatabase = async (app: INestApplication) => {
   await Chunk.create({
     duration: moment.duration(1, 'hour'),
     task: prepareForLogicExam,
-    start: newDate(new Date(2022, 12, 16, 50)),
+    start: newDate(2022, 12, 16, 50),
   }).save();
 
   await Chunk.create({
     duration: moment.duration(1, 'hour'),
     task: prepareForLogicExam,
-    start: newDate(new Date(2022, 12, 19, 50)),
+    start: newDate(2022, 12, 19, 50),
   }).save();
 
   const PrepareForPhysicsExam = await Task.create({
@@ -264,10 +264,10 @@ export const seedDatabase = async (app: INestApplication) => {
     isFloat: true,
     user: user,
     chunkInfo: {
-      start: newDate(new Date(2022, 12, 13)),
+      start: newDate(2022, 12, 13),
       minChunkDuration: moment.duration(1, 'hour'),
       maxChunkDuration: moment.duration(3, 'hour'),
-      deadline: newDate(new Date(2022, 11, 20, 0, 0)),
+      deadline: newDate(2022, 11, 20, 0, 0),
       estimation: moment.duration(5, 'hours'),
       chillTime: moment.duration(15, 'minutes'),
     },
@@ -278,13 +278,13 @@ export const seedDatabase = async (app: INestApplication) => {
   await Chunk.create({
     duration: moment.duration(1, 'hour'),
     task: PrepareForPhysicsExam,
-    start: newDate(new Date(2022, 12, 14, 20)),
+    start: newDate(2022, 12, 14, 20),
   }).save();
 
   await Chunk.create({
     duration: moment.duration(1, 'hour'),
     task: PrepareForPhysicsExam,
-    start: newDate(new Date(2022, 12, 15, 20)),
+    start: newDate(2022, 12, 15, 20),
   }).save();
 
   const prepareForASD = await Task.create({
@@ -294,11 +294,11 @@ export const seedDatabase = async (app: INestApplication) => {
     isFloat: true,
     user: user,
     chunkInfo: {
-      start: newDate(new Date(2022, 12, 13, 8, 0)),
+      start: newDate(2022, 12, 13, 8, 0),
       minChunkDuration: moment.duration(1, 'hour'),
       maxChunkDuration: moment.duration(3, 'hour'),
       estimation: moment.duration(6, 'hours'),
-      deadline: newDate(new Date(2022, 12, 21, 0, 0)),
+      deadline: newDate(2022, 12, 21, 0, 0),
       chillTime: moment.duration(15, 'minutes'),
     },
   }).save();

--- a/apps/server/src/tasks/tasks.service.ts
+++ b/apps/server/src/tasks/tasks.service.ts
@@ -40,8 +40,6 @@ export class TasksService {
       repeat: repeat,
     }).save();
 
-    // console.log(chunkInfo);
-
     const task = await Task.create({
       category: category,
       isFloat: false,
@@ -102,27 +100,11 @@ export class TasksService {
   }
 
   async upsertChunksForRepeatTask(task: Task) {
-    const chunkInfo = task.chunkInfo;
-
-    if (!chunkInfo) {
-      throw new UserInputError('Task is not a repeat task');
-    }
-
     const repeat = task.chunkInfo.repeat;
-
-    if (!repeat) {
-      throw "Task doesn't have a repeat pattern";
-    }
-
-    // First we need to remove all the existing chunks if they exist
-    await Chunk.createQueryBuilder('chunk')
-      .delete()
-      .where('"chunk"."taskId" = :taskId', { taskId: task.id })
-      .execute();
 
     const repeatUntil = repeat.repeatUntil
       ? moment(repeat.repeatUntil)
-      : moment(task.chunkInfo.start).add(2, 'month');
+      : moment(task.chunkInfo.start).clone().add(2, 'month');
 
     const chunkList = [];
     let currentChunkStart = moment(task.chunkInfo.start);
@@ -147,10 +129,8 @@ export class TasksService {
   }
 
   async getTasks(user: User, getTasksInput: GetTasksInput) {
-    const tasks = await Task.find({
+    const tasksWithoutChunks = await Task.find({
       relations: {
-        // Include chunks in case of float tasks
-        chunks: true,
         chunkInfo: {
           repeat: true,
         },
@@ -184,13 +164,25 @@ export class TasksService {
       take: getTasksInput.limit,
     });
 
-    tasks.forEach((task) => {
-      task.chunks.sort((a, b) => {
-        return a.start.getTime() - b.start.getTime();
-      });
-    });
+    return await Promise.all(
+      tasksWithoutChunks.map(async (task) => {
+        // If task is const then we need to limit chunks
+        task.chunks = await Chunk.find({
+          where: {
+            task: { id: task.id },
+            // TODO There we need to filter by start and end times when implementing calendar view
+          },
+          ...(!task.isFloat && {
+            take: 10,
+          }),
+          order: {
+            start: 'ASC' as const,
+          },
+        });
 
-    return tasks;
+        return task;
+      })
+    );
   }
 
   async getTask(user: User, id: string) {
@@ -198,7 +190,6 @@ export class TasksService {
       relations: ['chunks', 'chunkInfo', 'chunkInfo.repeat'],
       where: {
         user: { id: user.id },
-
         // Convert id to integer
         id: parseInt(id),
       },

--- a/apps/server/src/utils/myDate.ts
+++ b/apps/server/src/utils/myDate.ts
@@ -1,7 +1,0 @@
-export const newDate = (date: Date) => {
-  //   Set date's month to the previous month
-  date.setMonth(date.getMonth() - 1);
-  // Add a week
-  date.setDate(date.getDate() + 7);
-  return date;
-};

--- a/apps/server/src/utils/newDate.ts
+++ b/apps/server/src/utils/newDate.ts
@@ -1,0 +1,25 @@
+const newDate = (
+  year: number,
+  month: number,
+  day: number,
+  hour: number = 0,
+  minute = 0
+) => {
+  const date = new Date(year, month - 1, day, hour, minute);
+
+  // Find how many weeks have passed until now since date
+  const weeksPassed = Math.floor(
+    (new Date().getTime() - date.getTime()) / (1000 * 60 * 60 * 24 * 7)
+  );
+
+  if (weeksPassed <= 0) {
+    // Just add a week
+    date.setTime(date.getTime() + 1 * 7 * 24 * 60 * 60 * 1000);
+  } else {
+    date.setTime(date.getTime() + weeksPassed * 7 * 24 * 60 * 60 * 1000);
+  }
+
+  return date;
+};
+
+export default newDate;

--- a/apps/server/src/workers/taskPlanner.ts
+++ b/apps/server/src/workers/taskPlanner.ts
@@ -35,7 +35,6 @@ export class TaskPlanner {
       task.chunkInfo.start &&
       moment(task.chunkInfo.start).isBefore(moment())
     ) {
-      console.log('task.chunkInfo.start', task.chunkInfo.start);
       throw new Error(
         'Start date is in the past, but needs to be in the future.'
       );
@@ -176,7 +175,7 @@ export class TaskPlanner {
         .add(currentDuration.clone().add(chunk.chillTime));
     });
 
-    printWindows(windows);
+    // printWindows(windows);
 
     // Fit tasks in windows and calculate coefficients
     const chunksToInsert = [];

--- a/apps/server/tests/tasks/planTask.e2e-spec.ts
+++ b/apps/server/tests/tasks/planTask.e2e-spec.ts
@@ -1,6 +1,6 @@
-import moment, { Duration } from 'moment';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import moment, { Duration } from 'moment';
 import { AppModule } from '../../src/app/app.module';
 import { Category } from '../../src/categories/entities/category.entity';
 import { Color } from '../../src/categories/entities/color.entity';
@@ -10,6 +10,7 @@ import { Repeat, RepeatType } from '../../src/tasks/entities/repeat.entity';
 import { Task } from '../../src/tasks/entities/task.entity';
 import { TasksService } from '../../src/tasks/tasks.service';
 import { User } from '../../src/users/entities/user.entity';
+import newDate from '../../src/utils/newDate';
 import { TaskPlanner } from '../../src/workers/taskPlanner';
 import connection from '../connection';
 
@@ -124,7 +125,7 @@ describe('PlanTask (e2e)', () => {
       taskName: 'Sleep',
       category: sleepCategory,
       // New date in utc
-      start: newDate(new Date(2022, 11, 13, 0)),
+      start: newDate(2022, 11, 13, 0),
       duration: moment.duration(8, 'hours'),
       user: user,
       priority: 'high',
@@ -135,98 +136,98 @@ describe('PlanTask (e2e)', () => {
     await createConstTask({
       taskName: 'Imperative Programming',
       category: lectures_category,
-      start: newDate(new Date(2022, 11, 13, 11, 15)),
+      start: newDate(2022, 11, 13, 11, 15),
       user,
     });
 
     await createConstTask({
       taskName: 'English Language',
       category: labs_category,
-      start: newDate(new Date(2022, 11, 13, 14)),
+      start: newDate(2022, 11, 13, 14),
       user,
     });
 
     await createConstTask({
       taskName: 'Algorithms and Data Structures',
       category: lectures_category,
-      start: newDate(new Date(2022, 11, 14, 9, 35)),
+      start: newDate(2022, 11, 14, 9, 35),
       user,
     });
 
     await createConstTask({
       taskName: 'Mathematic Analysis',
       category: lectures_category,
-      start: newDate(new Date(2022, 11, 14, 11, 15)),
+      start: newDate(2022, 11, 14, 11, 15),
       user,
     });
 
     await createConstTask({
       taskName: 'Mathematical Logic',
       category: labs_category,
-      start: newDate(new Date(2022, 11, 14, 16, 15)),
+      start: newDate(2022, 11, 14, 16, 15),
       user,
     });
 
     await createConstTask({
       taskName: 'Physics',
       category: labs_category,
-      start: newDate(new Date(2022, 11, 15, 8)),
+      start: newDate(2022, 11, 15, 8),
       user,
     });
 
     await createConstTask({
       taskName: 'Mathematical Logic',
       category: lectures_category,
-      start: newDate(new Date(2022, 11, 15, 11, 15)),
+      start: newDate(2022, 11, 15, 11, 15),
       user,
     });
 
     await createConstTask({
       taskName: 'Intellectual Property',
       category: lectures_category,
-      start: newDate(new Date(2022, 11, 15, 12, 50)),
+      start: newDate(2022, 11, 15, 12, 50),
       user,
     });
 
     await createConstTask({
       taskName: 'Algorithms and Data Structures',
       category: lectures_category,
-      start: newDate(new Date(2022, 11, 15, 14, 40)),
+      start: newDate(2022, 11, 15, 14, 40),
       user,
     });
 
     await createConstTask({
       taskName: 'Algorithms and Data Structures',
       category: lectures_category,
-      start: newDate(new Date(2022, 11, 15, 14, 40)),
+      start: newDate(2022, 11, 15, 14, 40),
       user,
     });
 
     await createConstTask({
       taskName: 'Mathematical Analysis',
       category: labs_category,
-      start: newDate(new Date(2022, 11, 15, 14, 15)),
+      start: newDate(2022, 11, 15, 14, 15),
       user,
     });
 
     await createConstTask({
       taskName: 'Physics',
       category: lectures_category,
-      start: newDate(new Date(2022, 11, 16, 15, 45)),
+      start: newDate(2022, 11, 16, 15, 45),
       user,
     });
 
     await createConstTask({
       taskName: 'Physical Education',
       category: labs_category,
-      start: newDate(new Date(2022, 11, 17, 10, 15)),
+      start: newDate(2022, 11, 17, 10, 15),
       user,
     });
 
     await createConstTask({
       taskName: 'Imperative Programming',
       category: labs_category,
-      start: newDate(new Date(2022, 11, 17, 14, 40)),
+      start: newDate(2022, 11, 17, 14, 40),
       user,
     });
 
@@ -251,10 +252,10 @@ describe('PlanTask (e2e)', () => {
       isFloat: true,
       user: user,
       chunkInfo: {
-        start: newDate(new Date(2022, 11, 14)),
+        start: newDate(2022, 11, 14),
         minChunkDuration: moment.duration(1, 'hour'),
         maxChunkDuration: moment.duration(3, 'hour'),
-        deadline: newDate(new Date(2022, 11, 20, 0, 0)),
+        deadline: newDate(2022, 11, 20, 0, 0),
         estimation: moment.duration(4, 'hours'),
         chillTime: moment.duration(15, 'minutes'),
       },
@@ -264,13 +265,13 @@ describe('PlanTask (e2e)', () => {
     await Chunk.create({
       duration: moment.duration(1, 'hour'),
       task: prepareForLogicExam,
-      start: newDate(new Date(2022, 11, 16, 50)),
+      start: newDate(2022, 11, 16, 50),
     }).save();
 
     await Chunk.create({
       duration: moment.duration(1, 'hour'),
       task: prepareForLogicExam,
-      start: newDate(new Date(2022, 11, 19, 50)),
+      start: newDate(2022, 11, 19, 50),
     }).save();
 
     const PrepareForPhysicsExam = await Task.create({
@@ -280,10 +281,10 @@ describe('PlanTask (e2e)', () => {
       isFloat: true,
       user: user,
       chunkInfo: {
-        start: newDate(new Date(2022, 11, 14)),
+        start: newDate(2022, 11, 14),
         minChunkDuration: moment.duration(1, 'hour'),
         maxChunkDuration: moment.duration(3, 'hour'),
-        deadline: newDate(new Date(2022, 11, 20, 0, 0)),
+        deadline: newDate(2022, 11, 20, 0, 0),
         estimation: moment.duration(5, 'hours'),
         chillTime: moment.duration(15, 'minutes'),
       },
@@ -294,13 +295,13 @@ describe('PlanTask (e2e)', () => {
     await Chunk.create({
       duration: moment.duration(1, 'hour'),
       task: PrepareForPhysicsExam,
-      start: newDate(new Date(2022, 11, 14, 20)),
+      start: newDate(2022, 11, 14, 20),
     }).save();
 
     await Chunk.create({
       duration: moment.duration(1, 'hour'),
       task: PrepareForPhysicsExam,
-      start: newDate(new Date(2022, 11, 15, 20)),
+      start: newDate(2022, 11, 15, 20),
     }).save();
 
     const prepareForASD = await Task.create({
@@ -310,11 +311,11 @@ describe('PlanTask (e2e)', () => {
       isFloat: true,
       user: user,
       chunkInfo: {
-        start: newDate(new Date(2022, 12, 13, 8, 0)),
+        start: newDate(2022, 12, 13, 8, 0),
         minChunkDuration: moment.duration(1, 'hour'),
         maxChunkDuration: moment.duration(3, 'hour'),
         estimation: moment.duration(6, 'hours'),
-        deadline: newDate(new Date(2022, 11, 21, 0, 0)),
+        deadline: newDate(2022, 11, 21, 0, 0),
         chillTime: moment.duration(15, 'minutes'),
       },
     }).save();
@@ -325,11 +326,3 @@ describe('PlanTask (e2e)', () => {
   });
 });
 
-// TODO This function needs to add date to present moment
-const newDate = (date: Date) => {
-  //   Set date's month to the previous month
-  date.setMonth(date.getMonth() - 1);
-  // Add a week
-  date.setDate(date.getDate() + 14);
-  return date;
-};


### PR DESCRIPTION
- Limits chunks to 10 in `getTasks`
- Cleans db seeder to seed data for future only


I think we need to add additional filters to differ the queries coming from calendar view and from todo-list.

Also, now when creating a repeated task, we're inserting rows for 2 months in the future. I'm not sure if that's the desired behavior, but def lowest effort one.


//cc @karpinsk @szarbartosz  What are ur thoughts?

